### PR TITLE
Added save_path parameter.

### DIFF
--- a/tuneavideo/util.py
+++ b/tuneavideo/util.py
@@ -8,7 +8,14 @@ import torchvision
 from einops import rearrange
 
 
-def save_videos_grid(videos: torch.Tensor, path: str, rescale=False, n_rows=4, fps=3):
+def save_videos_grid(
+    videos: torch.Tensor, 
+    save_path: str = 'output',
+    path: str = 'output.gif', 
+    rescale=False, 
+    n_rows=4, 
+    fps=3
+):
     videos = rearrange(videos, "b c t h w -> t b c h w")
     outputs = []
     for x in videos:
@@ -18,6 +25,7 @@ def save_videos_grid(videos: torch.Tensor, path: str, rescale=False, n_rows=4, f
             x = (x + 1.0) / 2.0  # -1,1 -> 0,1
         x = (x * 255).numpy().astype(np.uint8)
         outputs.append(x)
-
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    imageio.mimsave(path, outputs, fps=fps)
+        
+    if not os.path.exists(save_path):
+        os.makedirs(save_path)
+    imageio.mimsave(os.path.join(save_path, path), outputs, fps=fps)


### PR DESCRIPTION
Inference Code:
```
from tuneavideo.pipelines.pipeline_tuneavideo import TuneAVideoPipeline
from tuneavideo.models.unet import UNet3DConditionModel
from tuneavideo.util import save_videos_grid
import torch

model_id = "Tune-A-Video-library/a-man-is-surfing"
unet = UNet3DConditionModel.from_pretrained(model_id, subfolder='unet', torch_dtype=torch.float16).to('cuda')
pipe = TuneAVideoPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", unet=unet, torch_dtype=torch.float16).to("cuda")

prompt = "a panda is surfing"
video = pipe(prompt, video_length=4, height=224, width=224, num_inference_steps=50, guidance_scale=7.5).videos

save_videos_grid(video, f"{prompt}.gif")
```
Output:
```
FileNotFoundError: [Errno 2] No such file or directory: ''
```

I resolved this error by adding the ```save_path``` parameter to the ```save_video_grid``` function.