### PR TITLE
Fix mid block checker to avoid problem with custom models

### DIFF
--- a/tuneavideo/models/unet.py
+++ b/tuneavideo/models/unet.py
@@ -139,7 +139,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin):
             self.down_blocks.append(down_block)
 
         # mid
-        if mid_block_type == "UNetMidBlock3DCrossAttn":
+        if mid_block_type in ["UNetMidBlock3DCrossAttn","UNetMidBlock2DCrossAttn"]:
             self.mid_block = UNetMidBlock3DCrossAttn(
                 in_channels=block_out_channels[-1],
                 temb_channels=time_embed_dim,


### PR DESCRIPTION
The from_pretrained_2d runs into `ValueError: unknown mid_block_type : UNetMidBlock2DCrossAttn` when `  "mid_block_type": "UNetMidBlock2DCrossAttn"` is specified in the config file of pretained unet.

This happens with some of the custom models (model converterscould be a cause), but won't happen with the official models.

This fix help void the problem by allowing  `UNetMidBlock2DCrossAttn` in the type check.

